### PR TITLE
⏩ skip useless transfers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1892,7 +1892,7 @@ dependencies = [
 
 [[package]]
 name = "rodalies-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "assert_cmd",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rodalies-cli"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Gerard C.L. <gerardcl@gmail.com>"]
 license = "BSD-3-Clause"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Timetables of the trains of Rodalies de la Generalitat de Catalunya on the termi
 
 `rodalies-cli` is written in [Rust](https://www.rust-lang.org/) and published to [crates.io](https://crates.io/crates/rodalies-cli), with it you can get timetables faster, no need to open an app nor a browser anymore.
 
-From release `1.0.0` one can search interactively the desired timetable. And, it has been refactored in a way that it is provided as a library too.
+From release `1.0.0`, one can interactively search the desired timetable. And, it has been refactored in a way that it is provided as a library too.
 
 ## Installation
 
@@ -17,7 +17,7 @@ After a release a github action updates it with x86_64 built binaries for:
 Run the following command to get the binary into your bin folder or tune it as you like:
 
 ```bash
-curl -LO "https://github.com/gerardcl/rodalies-cli/releases/download/1.0.0/rodalies-cli-linux-amd64" && \
+curl -LO "https://github.com/gerardcl/rodalies-cli/releases/download/1.0.1/rodalies-cli-linux-amd64" && \
 chmod +x rodalies-cli-linux-amd64 && mv rodalies-cli-linux-amd64 /usr/local/bin/rodalies-cli
 ```
 
@@ -28,7 +28,7 @@ chmod +x rodalies-cli-linux-amd64 && mv rodalies-cli-linux-amd64 /usr/local/bin/
 Run the following command to get the binary into your bin folder or tune it as you like:
 
 ```bash
-curl -LO "https://github.com/gerardcl/rodalies-cli/releases/download/1.0.0/rodalies-cli-darwin-amd64" && \
+curl -LO "https://github.com/gerardcl/rodalies-cli/releases/download/1.0.1/rodalies-cli-darwin-amd64" && \
 chmod +x rodalies-cli-darwin-amd64 && mv rodalies-cli-darwin-amd64 /usr/local/bin/rodalies-cli
 ```
 
@@ -39,7 +39,7 @@ chmod +x rodalies-cli-darwin-amd64 && mv rodalies-cli-darwin-amd64 /usr/local/bi
 Run the following command to get the binary into your bin folder or tune it as you like:
 
 ```bash
-curl -LO "https://github.com/gerardcl/rodalies-cli/releases/download/1.0.0/rodalies-cli-windows-amd64.exe" && \
+curl -LO "https://github.com/gerardcl/rodalies-cli/releases/download/1.0.1/rodalies-cli-windows-amd64.exe" && \
 chmod +x rodalies-cli-windows-amd64.exe && mv rodalies-cli-windows-amd64.exe /mingw64/bin/rodalies-cli.exe
 ```
 
@@ -86,7 +86,7 @@ Once you have `rodalies-cli` installed just run the help command to understand w
 
 ```bash
 $ rodalies-cli --help
-rodalies-cli 1.0.0
+rodalies-cli 1.0.1
 Gerard C.L. <gerardcl@gmail.com>
 CLI for searching train timetables of the trains of Rodalies de la Generalitat de Catalunya
 

--- a/src/rodalies/station.rs
+++ b/src/rodalies/station.rs
@@ -71,7 +71,7 @@ pub async fn search_station(client: &Client, args: &ArgMatches) -> Result<(), Bo
         results_table.printstd();
         Ok(())
     } else {
-        return Err(format!("🚨 No stations found with text '{}' in it, please try searching something else, and if the problem persists open an issue...", search).into());
+        Err(format!("🚨 No stations found with text '{}' in it, please try searching something else, and if the problem persists open an issue...", search).into())
     }
 }
 
@@ -102,6 +102,6 @@ pub async fn search_station_input(
         results_table.printstd();
         Ok(found_station_list)
     } else {
-        return Err(format!("🚨 No stations found with text '{}' in it, please try searching something else, and if the problem persists open an issue...", search).into());
+        Err(format!("🚨 No stations found with text '{}' in it, please try searching something else, and if the problem persists open an issue...", search).into())
     }
 }


### PR DESCRIPTION
fixes #11 

What has been detected is that sometimes Rodalies web service might return trips of a timetable that end at same time, but one of them has more transfers. This, so far, has been seen as an error since it does not make sense to make the user get a train earlier to finally get to the same arrival time. Instead, `rodalies-cli` filters those longer trips out and just keeps the fastest ones, which in turn means one does not need to go earlier to the departure destination.